### PR TITLE
add new image and switch to $is_args

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<img src="https://d1q6f0aelx0por.cloudfront.net/fa443219-42e0-4886-96b4-8733de694b72-c641a5d6-1ebf-44ee-9607-aef9b4ca1a3b-logo_large.png" alt="Nginx"/>
-
+![Image of Nginx](https://cdn.openbridge.com/assets/images/openbridge-nginx-small.png)
 # NGINX Accelerated
 This is a Docker image creates a high performance, optimized image for NGINX. Deliver sites and applications with performance, reliability, security, and scale. This NGINX server offers advanced performance, web and mobile acceleration, security controls, application monitoring, and management.
 

--- a/conf/php/nginx/conf.d/location.conf
+++ b/conf/php/nginx/conf.d/location.conf
@@ -1,14 +1,18 @@
 location /
 {
-  try_files                    $uri $uri/ /app.php$uri$args /index.php$uri$args ;
-  error_page                   502 =200 @installing;
+  try_files                    $uri $uri/ /app.php$is_args$args /index.php$is_args$args;
+
+  # Direct common errors to the temp maintenance page assuming there are no PHP resources available.
+  error_page                   502 =200 @maintenance;
+  error_page                   403 =200 @maintenance;
+
   aio                          threads;
   include                      /etc/nginx/redis.d/cache.conf;
 }
 
 location ~ [^/]\.php(/|$)
 {
-  try_files                    $uri $uri/ /app.php$uri$args /index.php$uri$args @php-fpm;
+  try_files                    $uri $uri/ /app.php$is_args$args /index.php$is_args$args @php-fpm;
   fastcgi_pass                 php-fpm;
   include                      /etc/nginx/fastcgi.d/fastcgi.conf;
   include                      /etc/nginx/redis.d/cache.conf;
@@ -22,9 +26,9 @@ location @php-fpm
   include                      /etc/nginx/redis.d/cache.conf;
 }
 
-location @installing {
+location @maintenance {
     default_type text/html;
-    try_files                 $uri $uri/ /install.html$uri$args;
+    try_files                 $uri $uri/ /install.html$is_args$args;
 }
 
 include                       /etc/nginx/conf.d/cdn.conf;


### PR DESCRIPTION
Wordpress seems to want the use of $is_args despite other examples showing otherwise