### PR TITLE
add example cookie no cache maps

### DIFF
--- a/conf/php/nginx/map.d/nocache/cookie.map
+++ b/conf/php/nginx/map.d/nocache/cookie.map
@@ -1,0 +1,5 @@
+~*comment_author 1;
+~*wp-postpass 1;
+~*wordpress_test_cookie 1;
+~*wordpress_no_cache* 1;
+~*wordpress_logged_in* 1;

--- a/conf/php/nginx/map.d/nocache/nocache.map
+++ b/conf/php/nginx/map.d/nocache/nocache.map
@@ -6,5 +6,7 @@ default 0;
 ~*\/administrator\/.* 1;
 ~*\/sitemap(_index)?.xml 1;
 ~*\/xmlrpc.php 1;
+~*\/wp-.*.php 1;
+~*\/index.php 1;
 HEAD 0;
 GET 0;

--- a/conf/php/nginx/nginx.conf
+++ b/conf/php/nginx/nginx.conf
@@ -108,7 +108,8 @@ http {
     map                                  $http_cookie $php_session_cookie {include /etc/nginx/map.d/cache/phpsession.map;}
 
     map                                  $request_uri $redirect_uri {include /etc/nginx/map.d/redirects/*.map;}
-    map                                  $request_uri $no_cache {include /etc/nginx/map.d/nocache/*.map;}
+    map                                  $request_uri $no_cache {include /etc/nginx/map.d/nocache/nocache.map;}
+    map                                  $http_cookie $no_cache {include /etc/nginx/map.d/nocache/cookie.map;}
 
     map                                  $http_user_agent $crawler_pre {include /etc/nginx/map.d/referrer/crawler.map;}
     map                                  $http_user_agent $bot_pre {include /etc/nginx/map.d/referrer/bot.map;}


### PR DESCRIPTION
these are examples of setting nocache for wordpress in a map