### PR TITLE
Fix nginx syntax to disable error logs

### DIFF
--- a/conf/html/nginx/conf.d/monit.conf
+++ b/conf/html/nginx/conf.d/monit.conf
@@ -7,6 +7,6 @@ location /monit/ {
     allow                       172.22.0.1;
     allow                       52.4.233.57;
     deny                        all;
-    access_log                  off;
-    error_log                   off;
+    access_log                  /dev/null;
+    error_log                   /dev/null;
 }


### PR DESCRIPTION
Setting `error_log off` will create a file named `off` in the directory where nginx is running.

See: https://www.wpoven.com/tutorial/how-to-disable-nginx-logs-on-your-server/